### PR TITLE
[codex] Optimize GIF playback and URLImage cache handling

### DIFF
--- a/Dependencies/Sources/DownloadManager/DownloadManager.swift
+++ b/Dependencies/Sources/DownloadManager/DownloadManager.swift
@@ -169,12 +169,12 @@ actor PublishersHolder {
         if let current = publishers[download.url] {
             publisher = current
             newTask = false
-            print("use exists task for \(download.url)")
+//            print("use exists task for \(download.url)")
         } else {
             publisher = DownloadAsyncTask(download: download, coordinator: coordinator)
             publishers[download.url] = publisher
             newTask = true
-            print("create new publisher for \(download.url)")
+//            print("create new publisher for \(download.url)")
         }
         let id = UUID()
         let (stream, continuation) = Stream.makeStream(bufferingPolicy: .bufferingNewest(1))

--- a/Dependencies/Tests/FileIndexTests/FileIndexTests.swift
+++ b/Dependencies/Tests/FileIndexTests/FileIndexTests.swift
@@ -122,6 +122,7 @@ final class FileIndexTests: XCTestCase {
         XCTAssertTrue(files2.isEmpty)
     }
 
+    @MainActor
     func testDeleteExpired() throws {
         let tmpLocation1 = makeTemporaryFile("This file expiring soon")
         let tmpLocation2 = makeTemporaryFile("This file expiring not so soon")
@@ -165,6 +166,7 @@ final class FileIndexTests: XCTestCase {
         waitForExpectations(timeout: 1.0)
     }
 
+    @MainActor
     func testDeleteAll() throws {
         let tmpLocation1 = makeTemporaryFile("This file expiring soon")
         let tmpLocation2 = makeTemporaryFile("This file expiring not so soon")

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,10 @@ let package = Package(
             targets: ["URLImage"]),
         .library(
             name: "URLImageStore",
-            targets: ["URLImageStore"])
+            targets: ["URLImageStore"]),
+        .library(
+            name: "URLImageFFmpeg",
+            targets: ["URLImageFFmpeg"])
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
@@ -29,7 +32,21 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "URLImage",
-            dependencies: [ "DownloadManager", "ImageDecoder", "FileIndex", "Model", "Log" ]),
+            dependencies: [
+                "DownloadManager",
+                "ImageDecoder",
+                "FileIndex",
+                "Model",
+                "Log",
+                .target(name: "URLImageFFmpeg", condition: .when(platforms: [.iOS, .macOS]))
+            ]),
+        .target(
+            name: "URLImageFFmpeg",
+            dependencies: [ "CURLImageFFmpeg" ]),
+        .target(
+            name: "CURLImageFFmpeg",
+            path: "Sources/CURLImageFFmpeg",
+            publicHeadersPath: "include"),
         .target(
             name: "URLImageStore",
             dependencies: [ "URLImage", "FileIndex", "Log" ]),

--- a/Sources/CURLImageFFmpeg/URLImageFFmpegBridge.c
+++ b/Sources/CURLImageFFmpeg/URLImageFFmpegBridge.c
@@ -1,0 +1,15 @@
+#include "URLImageFFmpegBridge.h"
+
+int32_t urlimage_ffmpeg_is_linked(void) {
+    return 0;
+}
+
+int32_t urlimage_ffmpeg_execute(int32_t argc, char * const argv[]) {
+    (void)argc;
+    (void)argv;
+    return -1;
+}
+
+const char *urlimage_ffmpeg_configuration(void) {
+    return "URLImageFFmpeg bridge stub: FFmpeg binary is not linked";
+}

--- a/Sources/CURLImageFFmpeg/include/URLImageFFmpegBridge.h
+++ b/Sources/CURLImageFFmpeg/include/URLImageFFmpegBridge.h
@@ -1,0 +1,18 @@
+#ifndef URLImageFFmpegBridge_h
+#define URLImageFFmpegBridge_h
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int32_t urlimage_ffmpeg_is_linked(void);
+int32_t urlimage_ffmpeg_execute(int32_t argc, char * const argv[]);
+const char *urlimage_ffmpeg_configuration(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/Sources/URLImage/RemoteImage/RemoteImage.swift
+++ b/Sources/URLImage/RemoteImage/RemoteImage.swift
@@ -184,7 +184,6 @@ public final class RemoteImage : ObservableObject, Sendable {
     
     private func notifyState(_ state: LoadingState) {
         let slowLoadingState = self.slowLoadingState
-        let id = download.id
         Task { @MainActor in
             slowLoadingState.send(state)
         }
@@ -216,7 +215,7 @@ extension RemoteImage {
             return false
         }
 
-        guard let transientImage: TransientImage = await store.getImage(keys) else {
+        guard let transientImage: TransientImage = await store.getImage(memoryKeys) else {
             log_debug(self, #function, "Image for \(download.url) not in the in memory store", detail: log_normal)
             return false
         }
@@ -256,11 +255,7 @@ extension RemoteImage {
             Task { [weak self] in
                 let success = await self?.returnStored() ?? false
                 if !success, let self {
-                    let task = Task { [weak self] in
-                        await self?.startDownload()
-                        return
-                    }
-                    await self.updateUpdatedTask(task)
+                    await self.updateUpdatedTask()
                 }
             }
         } else {
@@ -269,13 +264,8 @@ extension RemoteImage {
     }
     
     private func startAndUpdateDownload() {
-        let task = Task { [weak self] in
-            await self?.startDownload()
-            return
-        }
-        
         Task { [weak self] in
-            await self?.updateUpdatedTask(task)
+            await self?.updateUpdatedTask()
         }
     }
     
@@ -333,7 +323,9 @@ extension RemoteImage {
         // Store in memory
         let info = URLImageStoreInfo(url: download.url, identifier: identifier, uti: transientImage.uti)
 
-        await service.inMemoryStore?.store(transientImage, info: info)
+        if URLImageService.shouldStoreInMemory(uti: transientImage.uti) {
+            await service.inMemoryStore?.store(transientImage, info: info)
+        }
 
         // Complete
         loadingState.send(.success(transientImage))
@@ -350,9 +342,11 @@ extension RemoteImage {
     }
     
     @RemoteImageActor
-    private func updateUpdatedTask(_ task: Task<Void, Never>) {
+    private func updateUpdatedTask() {
         self.updatedTask?.cancel()
-        self.updatedTask = task
+        self.updatedTask = Task { [weak self] in
+            await self?.startDownload()
+        }
     }
 
     /// Helper to return `URLImageStoreKey` objects based on `URLImageOptions` and `Download` properties
@@ -367,5 +361,17 @@ extension RemoteImage {
         keys.append(.url(download.url))
 
         return keys
+    }
+
+    private var memoryKeys: [URLImageKey] {
+        Self.memoryLookupKeys(identifier: identifier, url: download.url)
+    }
+
+    nonisolated static func memoryLookupKeys(identifier: String?, url: URL) -> [URLImageKey] {
+        if let identifier {
+            return [.identifier(identifier)]
+        }
+
+        return [.url(url)]
     }
 }

--- a/Sources/URLImage/Service/URLImageService+Decode.swift
+++ b/Sources/URLImage/Service/URLImageService+Decode.swift
@@ -24,7 +24,9 @@ extension URLImageService {
                 if shouldStore {
                     let info = URLImageStoreInfo(url: download.url, identifier: identifier, uti: transientImage.uti)
                     fileStore?.storeImageData(data, info: info)
-                    await inMemoryStore?.store(transientImage, info: info)
+                    if Self.shouldStoreInMemory(uti: transientImage.uti) {
+                        await inMemoryStore?.store(transientImage, info: info)
+                    }
                 }
 
                 return transientImage
@@ -40,7 +42,9 @@ extension URLImageService {
                 if shouldStore {
                     let info = URLImageStoreInfo(url: download.url, identifier: identifier, uti: transientImage.uti)
                     fileStore?.moveImageFile(from: location, info: info)
-                    await inMemoryStore?.store(transientImage, info: info)
+                    if Self.shouldStoreInMemory(uti: transientImage.uti) {
+                        await inMemoryStore?.store(transientImage, info: info)
+                    }
                 }
 
                 return transientImage
@@ -49,5 +53,13 @@ extension URLImageService {
 
     private var shouldStore: Bool {
         fileStore != nil || inMemoryStore != nil
+    }
+
+    nonisolated static func shouldStoreInMemory(uti: String) -> Bool {
+#if os(macOS)
+        return uti != "com.compuserve.gif"
+#else
+        return true
+#endif
     }
 }

--- a/Sources/URLImage/Store/URLImageFileStoreType+Combine.swift
+++ b/Sources/URLImage/Store/URLImageFileStoreType+Combine.swift
@@ -28,6 +28,21 @@ extension URLImageFileStoreType {
             }
         }
     }
+
+    public func getImageLocation(_ keys: [URLImageKey]) async throws -> URL? {
+        try await withCheckedThrowingContinuation { continuation in
+            getImage(keys) { location -> URL? in
+                location
+            } completion: { result in
+                switch result {
+                case .success(let url):
+                    continuation.resume(returning: url)
+                case .failure(let error):
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
     
     public func getImageLocation(_ identifier: String) async throws -> URL? {
         try await withCheckedThrowingContinuation { continuation in

--- a/Sources/URLImage/URLImage.swift
+++ b/Sources/URLImage/URLImage.swift
@@ -317,10 +317,12 @@ struct InstalledRemoteView<Content: View>: View {
     private func inital() {
         let image = service.makeRemoteImage(url: url, identifier: identifier, options: options)
         remoteImage.remote = image
-        if options.loadOptions.contains(.loadImmediately) || options.loadOptions.contains(.loadOnAppear) {
+        if Self.shouldStartLoadingDuringInstallation(loadOptions: options.loadOptions) {
             image.load()
         }
     }
+
+    nonisolated static func shouldStartLoadingDuringInstallation(loadOptions: URLImageOptions.LoadOptions) -> Bool {
+        loadOptions.contains(.loadImmediately)
+    }
 }
-
-

--- a/Sources/URLImage/Views/GIFImage.swift
+++ b/Sources/URLImage/Views/GIFImage.swift
@@ -14,7 +14,6 @@ public typealias PlatformViewRepresentable = UIViewRepresentable
 public typealias PlatformImage = UIImage
 public typealias PlatformImageView = UIImageView
 #elseif os(macOS)
-import Quartz
 public typealias PlatformView = NSView
 public typealias PlatformImage = NSImage
 public typealias PlatformImageView = NSImageView
@@ -24,6 +23,11 @@ public typealias PlatformViewRepresentable = NSViewRepresentable
 public enum GIFImageSource {
     case image(PlatformImage)
     case file(URL)
+}
+
+public enum GIFPlaybackMode: Sendable {
+    case poster
+    case animated
 }
 
 @available(macOS 12.0, iOS 15.0, *)
@@ -36,6 +40,7 @@ public struct GIFImage<Empty, InProgress, Failure, Content> : View where Empty :
     
     var url: URL
     private let identifier: String?
+    private let playbackMode: GIFPlaybackMode
     
     private let empty: () -> Empty
     private let inProgress: (_ progress: Float?) -> InProgress
@@ -44,6 +49,7 @@ public struct GIFImage<Empty, InProgress, Failure, Content> : View where Empty :
     
     public init(_ url: URL,
                 identifier: String? = nil,
+                playbackMode: GIFPlaybackMode = .animated,
                  @ViewBuilder empty: @escaping () -> Empty,
                  @ViewBuilder inProgress: @escaping (_ progress: Float?) -> InProgress,
                  @ViewBuilder failure: @escaping (_ error: Error, _ retry: @escaping () -> Void) -> Failure,
@@ -51,6 +57,7 @@ public struct GIFImage<Empty, InProgress, Failure, Content> : View where Empty :
         
         self.url = url
         self.identifier = identifier
+        self.playbackMode = playbackMode
         self.empty = empty
         self.inProgress = inProgress
         self.failure = failure
@@ -61,6 +68,7 @@ public struct GIFImage<Empty, InProgress, Failure, Content> : View where Empty :
         InstalledRemoteView(service: urlImageService, url: url, identifier: identifier, options: options) { remoteImage in
             RemoteGIFImageView(remoteImage: remoteImage,
                                loadOptions: options.loadOptions,
+                               playbackMode: playbackMode,
                                empty: empty,
                                inProgress: inProgress,
                                failure: failure,
@@ -72,28 +80,34 @@ public struct GIFImage<Empty, InProgress, Failure, Content> : View where Empty :
 @available(macOS 11.0, iOS 14.0, *)
 public struct GIFImageView: View {
     var source: GIFImageSource
+    var playbackMode: GIFPlaybackMode
+    var preferredMaxPixelSize: CGSize?
     @Environment(\.imageConfigures) var imageConfigures
     
-    init(image: PlatformImage) {
+    init(image: PlatformImage, playbackMode: GIFPlaybackMode = .animated, preferredMaxPixelSize: CGSize? = nil) {
         self.source = .image(image)
+        self.playbackMode = playbackMode
+        self.preferredMaxPixelSize = preferredMaxPixelSize
     }
     
-    init(url: URL) {
+    init(url: URL, playbackMode: GIFPlaybackMode = .animated, preferredMaxPixelSize: CGSize? = nil) {
         self.source = .file(url)
+        self.playbackMode = playbackMode
+        self.preferredMaxPixelSize = preferredMaxPixelSize
     }
     
     public var body: some View {
         if imageConfigures.resizeble, let aspectRatio = imageConfigures.aspectRatio {
-            GIFRepresentView(source: source)
+            GIFRepresentView(source: source, playbackMode: playbackMode, preferredMaxPixelSize: preferredMaxPixelSize)
                 .aspectRatio(aspectRatio, contentMode: imageConfigures.contentMode == .fit ? .fit:.fill)
         }   else    {
-            GIFRepresentView(source: source)
+            GIFRepresentView(source: source, playbackMode: playbackMode, preferredMaxPixelSize: preferredMaxPixelSize)
         }
     }
 }
 
 public extension View {
-    func aspectResizeble(ratio: CGFloat, contentMode: ContentMode = .fit) -> some View {
+    func aspectResizeble(ratio: CGFloat, contentMode: GIFContentMode = .fit) -> some View {
         self.environment(\.imageConfigures, ImageConfigures(aspectRatio: ratio, contentMode: contentMode, resizeble: true))
     }
 }
@@ -101,86 +115,122 @@ public extension View {
 @available(macOS 11.0, iOS 14.0, *)
 struct GIFRepresentView: PlatformViewRepresentable {
     var source: GIFImageSource
+    var playbackMode: GIFPlaybackMode
+    var preferredMaxPixelSize: CGSize?
     @Environment(\.imageConfigures) var imageConfigures
     
 #if os(iOS) || os(watchOS)
     public func makeUIView(context: Context) -> PlatformView {
-        switch source {
-        case .image(let image):
-            return UIGIFImage(source: image)
-        case .file(let url):
-            return PlatformView()
-        }
+        let view = UIGIFImage()
+        view.update(source: source, contentMode: imageConfigures.contentMode, playbackMode: playbackMode)
+        return view
     }
     
     public func updateUIView(_ uiView: PlatformView, context: Context) {
-        
+        (uiView as? UIGIFImage)?.update(source: source, contentMode: imageConfigures.contentMode, playbackMode: playbackMode)
     }
 #elseif os(macOS)
     public func makeNSView(context: Context) -> PlatformView {
-        switch source {
-        case .image(let image):
-            return UIGIFImage(source: image)
-        case .file(let url):
-            guard let preview = QLPreviewView(frame: .zero, style: .normal) else {
-                return QLPreviewView()
-            }
-            preview.shouldCloseWithWindow = false
-            preview.autostarts = true
-            preview.previewItem = url as QLPreviewItem
-            preview.refreshPreviewItem()
-            return preview
-        }
+        let view = MacAnimatedGIFView()
+        view.update(source: source,
+                    contentMode: imageConfigures.contentMode,
+                    playbackMode: playbackMode,
+                    preferredMaxPixelSize: preferredMaxPixelSize)
+        return view
     }
     
     public func updateNSView(_ nsView: PlatformView, context: Context) {
-        
+        (nsView as? MacAnimatedGIFView)?.update(source: source,
+                                                contentMode: imageConfigures.contentMode,
+                                                playbackMode: playbackMode,
+                                                preferredMaxPixelSize: preferredMaxPixelSize)
+    }
+
+    public static func dismantleNSView(_ nsView: PlatformView, coordinator: ()) {
+        (nsView as? MacAnimatedGIFView)?.reset()
     }
 #endif
 }
 
 public final class UIGIFImage: PlatformView {
     let imageView = PlatformImageView()
-    var source: PlatformImage?
-    var imageConfigures: ImageConfigures?
+    private var source: GIFImageSource?
+    private var playbackMode: GIFPlaybackMode = .animated
+    private var imageConfigures: ImageConfigures?
     
     override init(frame: CGRect) {
         super.init(frame: frame)
+        initView()
     }
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
     
-    convenience init(source: PlatformImage) {
-        self.init()
-        self.source = source
-        initView()
-    }
-    
 #if os(iOS) || os(watchOS)
     public override func layoutSubviews() {
         super.layoutSubviews()
         imageView.frame = bounds
-        addSubview(imageView)
+        if imageView.superview == nil {
+            addSubview(imageView)
+        }
     }
 #elseif os(macOS)
     public override func layout() {
         super.layout()
         imageView.frame = bounds
-        addSubview(imageView)
+        if imageView.superview == nil {
+            addSubview(imageView)
+        }
     }
 #endif
     
     private func initView() {
 #if os(iOS) || os(watchOS)
-        imageView.contentMode = imageConfigures?.contentMode == .fit ? .scaleAspectFit:.scaleAspectFill
-        imageView.image = source
+        imageView.contentMode = .scaleAspectFit
 #elseif os(macOS)
-        imageView.imageScaling = imageConfigures?.contentMode == .fit ? .scaleAxesIndependently:.scaleProportionallyUpOrDown
-        imageView.image = source
-        imageView.animates = true
+        imageView.imageScaling = .scaleAxesIndependently
+        imageView.animates = false
 #endif
+    }
+
+    func update(source: GIFImageSource, contentMode: GIFContentMode, playbackMode: GIFPlaybackMode) {
+        self.source = source
+        self.playbackMode = playbackMode
+        self.imageConfigures = ImageConfigures(aspectRatio: nil, contentMode: contentMode, resizeble: false)
+#if os(iOS) || os(watchOS)
+        imageView.contentMode = contentMode == .fit ? .scaleAspectFit:.scaleAspectFill
+#elseif os(macOS)
+        imageView.imageScaling = contentMode == .fit ? .scaleAxesIndependently:.scaleProportionallyUpOrDown
+#endif
+        apply()
+    }
+
+    private func apply() {
+        guard let source else {
+            imageView.image = nil
+            return
+        }
+
+        switch source {
+        case .image(let image):
+#if os(iOS) || os(watchOS)
+            imageView.stopAnimating()
+            switch playbackMode {
+            case .animated:
+                imageView.image = image
+                imageView.startAnimating()
+            case .poster:
+                imageView.image = image.images?.first ?? image
+            }
+#elseif os(macOS)
+            imageView.animates = false
+            imageView.image = image
+            imageView.animates = playbackMode == .animated
+#endif
+        case .file:
+            break
+        }
     }
 }
 
@@ -209,14 +259,14 @@ public struct Scenes: Sendable {
 #endif
 }
 
-public enum ContentMode: Sendable {
+public enum GIFContentMode: Sendable {
     case fit
     case fill
 }
 
 struct ImageConfigures: Sendable {
     var aspectRatio: CGFloat?
-    var contentMode: ContentMode
+    var contentMode: GIFContentMode
     var resizeble: Bool
     
     func aspectRatio(_ aspectRatio: CGFloat) -> ImageConfigures {
@@ -225,7 +275,7 @@ struct ImageConfigures: Sendable {
         return configures
     }
 
-    func contentMode(_ contentMode: ContentMode) -> ImageConfigures {
+    func contentMode(_ contentMode: GIFContentMode) -> ImageConfigures {
         var configures = self
         configures.contentMode = contentMode
         return configures

--- a/Sources/URLImage/Views/GIFPlaybackEngine.swift
+++ b/Sources/URLImage/Views/GIFPlaybackEngine.swift
@@ -1,0 +1,184 @@
+#if os(macOS)
+import Foundation
+import CoreGraphics
+import ImageDecoder
+
+@available(macOS 11.0, *)
+@MainActor
+final class GIFPlaybackEngine {
+    typealias FrameHandler = @MainActor (CGImage?) -> Void
+
+    private let decoder: ImageDecoder
+    private let maxPixelSize: CGSize?
+    private let frameHandler: FrameHandler
+    private let frameCount: Int
+    private let frameDurations: [TimeInterval]
+
+    private var playbackTask: Task<Void, Never>?
+    private var decodeTasks: [Int: Task<CGImage?, Never>] = [:]
+    private var frameCache: [Int: CGImage] = [:]
+
+    private let prefetchDepth = 1
+
+    init?(url: URL, maxPixelSize: CGSize?, frameHandler: @escaping FrameHandler) {
+        guard let decoder = ImageDecoder(url: url) else {
+            return nil
+        }
+
+        let frameCount = max(decoder.frameCount, 1)
+
+        self.decoder = decoder
+        self.maxPixelSize = maxPixelSize
+        self.frameHandler = frameHandler
+        self.frameCount = frameCount
+        self.frameDurations = (0..<frameCount).map { index in
+            max(decoder.frameDuration(at: index) ?? 0.1, 0.02)
+        }
+    }
+
+    func start() {
+        guard playbackTask == nil else {
+            return
+        }
+
+        playbackTask = Task { [weak self] in
+            await self?.runPlaybackLoop()
+        }
+    }
+
+    func showPoster() {
+        stopPlayback(keepPoster: true)
+
+        Task { [weak self] in
+            guard let self else {
+                return
+            }
+
+            let poster = await frame(at: 0)
+            frameHandler(poster)
+        }
+    }
+
+    func posterFrame() async -> CGImage? {
+        await frame(at: 0)
+    }
+
+    func invalidate() {
+        stopPlayback(keepPoster: false)
+        frameCache.removeAll()
+        decodeTasks.values.forEach { $0.cancel() }
+        decodeTasks.removeAll()
+    }
+
+    private func runPlaybackLoop() async {
+        var frameIndex = 0
+
+        while !Task.isCancelled {
+            let frame = await frame(at: frameIndex)
+            guard !Task.isCancelled else {
+                break
+            }
+            frameHandler(frame)
+            prefetchFrames(after: frameIndex)
+
+            let delay = frameDurations[frameIndex]
+            let sleepNanoseconds = UInt64(delay * 1_000_000_000)
+            try? await Task.sleep(nanoseconds: sleepNanoseconds)
+
+            frameIndex = (frameIndex + 1) % frameCount
+        }
+    }
+
+    private func frame(at index: Int) async -> CGImage? {
+        if let cached = frameCache[index] {
+            return cached
+        }
+
+        if let existingTask = decodeTasks[index] {
+            let image = await existingTask.value
+            if let image {
+                cache(image, for: index)
+            }
+            return image
+        }
+
+        let task = Task.detached(priority: .utility) { [decoder, maxPixelSize] () -> CGImage? in
+            guard !Task.isCancelled else {
+                return nil
+            }
+            let decodingOptions = ImageDecoder.DecodingOptions(mode: .asynchronous, sizeForDrawing: maxPixelSize)
+            let image = decoder.createFrameImage(at: index, decodingOptions: decodingOptions)
+            guard !Task.isCancelled else {
+                return nil
+            }
+            return image
+        }
+
+        decodeTasks[index] = task
+        let image = await task.value
+        decodeTasks[index] = nil
+
+        if let image {
+            cache(image, for: index)
+        }
+
+        return image
+    }
+
+    private func prefetchFrames(after index: Int) {
+        guard frameCount > 1 else {
+            return
+        }
+
+        for offset in 1...prefetchDepth {
+            let nextIndex = (index + offset) % frameCount
+            guard frameCache[nextIndex] == nil, decodeTasks[nextIndex] == nil else {
+                continue
+            }
+
+            decodeTasks[nextIndex] = Task.detached(priority: .background) { [decoder, maxPixelSize] () -> CGImage? in
+                guard !Task.isCancelled else {
+                    return nil
+                }
+                let decodingOptions = ImageDecoder.DecodingOptions(mode: .asynchronous, sizeForDrawing: maxPixelSize)
+                let image = decoder.createFrameImage(at: nextIndex, decodingOptions: decodingOptions)
+                guard !Task.isCancelled else {
+                    return nil
+                }
+                return image
+            }
+        }
+    }
+
+    private func cache(_ image: CGImage, for index: Int) {
+        frameCache[index] = image
+
+        let keepIndices = Set([
+            0,
+            index,
+            (index + 1) % frameCount
+        ])
+
+        frameCache = frameCache.filter { keepIndices.contains($0.key) }
+
+        for key in Array(decodeTasks.keys) where !keepIndices.contains(key) {
+            decodeTasks[key]?.cancel()
+            decodeTasks[key] = nil
+        }
+    }
+
+    private func stopPlayback(keepPoster: Bool) {
+        playbackTask?.cancel()
+        playbackTask = nil
+
+        decodeTasks.values.forEach { $0.cancel() }
+        decodeTasks.removeAll()
+
+        if keepPoster, let poster = frameCache[0] {
+            frameCache = [0: poster]
+        } else if !keepPoster {
+            frameCache.removeAll()
+        }
+    }
+}
+#endif

--- a/Sources/URLImage/Views/GIFVideoTranscodeCache.swift
+++ b/Sources/URLImage/Views/GIFVideoTranscodeCache.swift
@@ -1,0 +1,475 @@
+#if os(macOS)
+@preconcurrency import Foundation
+@preconcurrency import AVFoundation
+import CoreGraphics
+import CryptoKit
+@preconcurrency import ImageIO
+import os
+import URLImageFFmpeg
+
+@available(macOS 11.0, *)
+actor GIFVideoTranscodeCache {
+    static let shared = GIFVideoTranscodeCache()
+
+    private static let logger = Logger(subsystem: "com.groovy.ca", category: "GIFPlayback")
+    private static let transcodeLimiter = GIFVideoTranscodeLimiter(maxConcurrentJobs: 1)
+    private static let cacheFormatVersion = "upright-v2"
+
+    private var activeTasks: [String: Task<URL, Error>] = [:]
+
+    nonisolated func cachedVideoURL(for gifURL: URL, maxPixelSize: CGSize?) -> URL? {
+        guard let location = try? Self.cacheLocation(for: gifURL, maxPixelSize: maxPixelSize),
+              FileManager.default.fileExists(atPath: location.videoURL.path) else {
+            return nil
+        }
+
+        return location.videoURL
+    }
+
+    func videoURL(for gifURL: URL, maxPixelSize: CGSize?) async throws -> URL {
+        let location = try Self.cacheLocation(for: gifURL, maxPixelSize: maxPixelSize)
+
+        if FileManager.default.fileExists(atPath: location.videoURL.path) {
+            Self.logger.notice("gif video cache hit source=\(gifURL.lastPathComponent, privacy: .public) video=\(location.videoURL.lastPathComponent, privacy: .public)")
+            return location.videoURL
+        }
+
+        if let task = activeTasks[location.key] {
+            Self.logger.notice("gif video transcode join source=\(gifURL.lastPathComponent, privacy: .public)")
+            return try await task.value
+        }
+
+        let task = Task(priority: .utility) {
+            try await Self.withTranscodePermit {
+                try await Self.transcode(gifURL: gifURL,
+                                         outputURL: location.videoURL,
+                                         temporaryURL: location.temporaryURL,
+                                         maxPixelSize: maxPixelSize)
+            }
+        }
+
+        activeTasks[location.key] = task
+        defer {
+            activeTasks[location.key] = nil
+        }
+
+        return try await task.value
+    }
+
+    private static func withTranscodePermit<T>(_ operation: () async throws -> T) async throws -> T {
+        await transcodeLimiter.acquire()
+
+        do {
+            let value = try await operation()
+            await transcodeLimiter.release()
+            return value
+        } catch {
+            await transcodeLimiter.release()
+            throw error
+        }
+    }
+
+    private static func transcode(gifURL: URL,
+                                  outputURL: URL,
+                                  temporaryURL: URL,
+                                  maxPixelSize: CGSize?) async throws -> URL {
+        try Task.checkCancellation()
+        try FileManager.default.createDirectory(at: outputURL.deletingLastPathComponent(),
+                                                withIntermediateDirectories: true)
+        try? FileManager.default.removeItem(at: temporaryURL)
+
+        let startedAt = ProcessInfo.processInfo.systemUptime
+        logger.notice("gif video transcode start source=\(gifURL.lastPathComponent, privacy: .public) output=\(outputURL.lastPathComponent, privacy: .public) maxPixel=\(String(describing: maxPixelSize), privacy: .public)")
+
+        do {
+            if EmbeddedFFmpegGIFTranscoder.isLinked {
+                logger.notice("gif video embedded ffmpeg source=\(gifURL.lastPathComponent, privacy: .public) config=\(EmbeddedFFmpegGIFTranscoder.configuration, privacy: .public)")
+                try await runEmbeddedFFmpeg(sourceURL: gifURL,
+                                            outputURL: temporaryURL,
+                                            maxPixelSize: maxPixelSize)
+            } else {
+                logger.notice("gif video embedded ffmpeg unavailable, using avasset source=\(gifURL.lastPathComponent, privacy: .public) config=\(EmbeddedFFmpegGIFTranscoder.configuration, privacy: .public)")
+                try await runAVAssetWriterTranscode(sourceURL: gifURL,
+                                                    outputURL: temporaryURL,
+                                                    maxPixelSize: maxPixelSize)
+            }
+            try Task.checkCancellation()
+
+            if FileManager.default.fileExists(atPath: outputURL.path) {
+                try FileManager.default.removeItem(at: outputURL)
+            }
+
+            try FileManager.default.moveItem(at: temporaryURL, to: outputURL)
+            let elapsed = ProcessInfo.processInfo.systemUptime - startedAt
+            logger.notice("gif video transcode finish source=\(gifURL.lastPathComponent, privacy: .public) elapsed=\(elapsed, privacy: .public)")
+            return outputURL
+        } catch {
+            try? FileManager.default.removeItem(at: temporaryURL)
+            logger.error("gif video transcode fail source=\(gifURL.lastPathComponent, privacy: .public) error=\(String(describing: error), privacy: .public)")
+            throw error
+        }
+    }
+
+    private static func runEmbeddedFFmpeg(sourceURL: URL,
+                                          outputURL: URL,
+                                          maxPixelSize: CGSize?) async throws {
+        let request = FFmpegGIFTranscodeRequest(sourceURL: sourceURL,
+                                                outputURL: outputURL,
+                                                maxPixelSize: maxPixelSize)
+        let transcoder = EmbeddedFFmpegGIFTranscoder(preset: .appleH264)
+
+        try await Task.detached(priority: .utility) {
+            try Task.checkCancellation()
+            try transcoder.transcode(request)
+            try Task.checkCancellation()
+        }.value
+    }
+
+    private static func runAVAssetWriterTranscode(sourceURL: URL,
+                                                  outputURL: URL,
+                                                  maxPixelSize: CGSize?) async throws {
+        try Task.checkCancellation()
+
+        guard let imageSource = CGImageSourceCreateWithURL(sourceURL as CFURL, nil) else {
+            throw GIFVideoTranscodeError.imageSourceUnavailable
+        }
+
+        let frameCount = max(CGImageSourceGetCount(imageSource), 1)
+        guard let firstFrame = CGImageSourceCreateImageAtIndex(imageSource, 0, nil) else {
+            throw GIFVideoTranscodeError.frameUnavailable(index: 0)
+        }
+
+        let videoSize = outputVideoSize(sourceWidth: firstFrame.width,
+                                        sourceHeight: firstFrame.height,
+                                        maxPixelSize: maxPixelSize)
+        let writer = try AVAssetWriter(outputURL: outputURL, fileType: .mp4)
+        let input = AVAssetWriterInput(mediaType: .video,
+                                       outputSettings: videoOutputSettings(videoSize: videoSize))
+        input.expectsMediaDataInRealTime = false
+
+        let adaptor = AVAssetWriterInputPixelBufferAdaptor(assetWriterInput: input,
+                                                           sourcePixelBufferAttributes: pixelBufferAttributes(videoSize: videoSize))
+
+        guard writer.canAdd(input) else {
+            throw GIFVideoTranscodeError.assetWriterInputRejected
+        }
+
+        writer.add(input)
+
+        guard writer.startWriting() else {
+            throw writer.error ?? GIFVideoTranscodeError.assetWriterFailed("startWriting failed")
+        }
+
+        writer.startSession(atSourceTime: .zero)
+        try await appendFrames(from: imageSource,
+                               frameCount: frameCount,
+                               videoSize: videoSize,
+                               input: input,
+                               adaptor: adaptor)
+        try await finishWriting(writer)
+    }
+
+    private static func appendFrames(from imageSource: CGImageSource,
+                                     frameCount: Int,
+                                     videoSize: VideoSize,
+                                     input: AVAssetWriterInput,
+                                     adaptor: AVAssetWriterInputPixelBufferAdaptor) async throws {
+        let queue = DispatchQueue(label: "com.groovy.ca.gif-video-transcode.writer", qos: .utility)
+
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            let appender = FrameAppender(imageSource: imageSource,
+                                         frameCount: frameCount,
+                                         videoSize: videoSize,
+                                         input: input,
+                                         adaptor: adaptor)
+
+            input.requestMediaDataWhenReady(on: queue) {
+                appender.appendReadyFrames(continuation: continuation)
+            }
+        }
+    }
+
+    private final class FrameAppender: @unchecked Sendable {
+        private let imageSource: CGImageSource
+        private let frameCount: Int
+        private let videoSize: VideoSize
+        private let input: AVAssetWriterInput
+        private let adaptor: AVAssetWriterInputPixelBufferAdaptor
+        private let timescale: CMTimeScale = 600
+
+        private var frameIndex = 0
+        private var presentationTime = CMTime.zero
+        private var lastImage: CGImage?
+        private var appendedTerminalFrame = false
+        private var resumed = false
+
+        init(imageSource: CGImageSource,
+             frameCount: Int,
+             videoSize: VideoSize,
+             input: AVAssetWriterInput,
+             adaptor: AVAssetWriterInputPixelBufferAdaptor) {
+            self.imageSource = imageSource
+            self.frameCount = frameCount
+            self.videoSize = videoSize
+            self.input = input
+            self.adaptor = adaptor
+        }
+
+        func appendReadyFrames(continuation: CheckedContinuation<Void, Error>) {
+            guard !resumed else {
+                return
+            }
+
+            do {
+                while input.isReadyForMoreMediaData {
+                    if frameIndex < frameCount {
+                        guard let image = CGImageSourceCreateImageAtIndex(imageSource, frameIndex, nil) else {
+                            throw GIFVideoTranscodeError.frameUnavailable(index: frameIndex)
+                        }
+
+                        let pixelBuffer = try makePixelBuffer(image: image,
+                                                              videoSize: videoSize,
+                                                              adaptor: adaptor)
+                        guard adaptor.append(pixelBuffer, withPresentationTime: presentationTime) else {
+                            throw GIFVideoTranscodeError.assetWriterFailed("append failed")
+                        }
+
+                        lastImage = image
+                        presentationTime = presentationTime + CMTime(seconds: frameDuration(imageSource: imageSource, index: frameIndex),
+                                                                     preferredTimescale: timescale)
+                        frameIndex += 1
+                    } else if !appendedTerminalFrame, let lastImage {
+                        let pixelBuffer = try makePixelBuffer(image: lastImage,
+                                                              videoSize: videoSize,
+                                                              adaptor: adaptor)
+                        guard adaptor.append(pixelBuffer, withPresentationTime: presentationTime) else {
+                            throw GIFVideoTranscodeError.assetWriterFailed("append terminal frame failed")
+                        }
+                        appendedTerminalFrame = true
+                    } else {
+                        input.markAsFinished()
+                        resumed = true
+                        continuation.resume(returning: ())
+                        return
+                    }
+                }
+            } catch {
+                input.markAsFinished()
+                resumed = true
+                continuation.resume(throwing: error)
+            }
+        }
+    }
+
+    private static func finishWriting(_ writer: AVAssetWriter) async throws {
+        await withCheckedContinuation { continuation in
+            writer.finishWriting {
+                continuation.resume()
+            }
+        }
+
+        guard writer.status == .completed else {
+            throw writer.error ?? GIFVideoTranscodeError.assetWriterFailed("finishWriting status=\(writer.status.rawValue)")
+        }
+    }
+
+    private static func makePixelBuffer(image: CGImage,
+                                        videoSize: VideoSize,
+                                        adaptor: AVAssetWriterInputPixelBufferAdaptor) throws -> CVPixelBuffer {
+        guard let pixelBufferPool = adaptor.pixelBufferPool else {
+            throw GIFVideoTranscodeError.pixelBufferPoolUnavailable
+        }
+
+        var pixelBuffer: CVPixelBuffer?
+        let status = CVPixelBufferPoolCreatePixelBuffer(nil, pixelBufferPool, &pixelBuffer)
+        guard status == kCVReturnSuccess, let pixelBuffer else {
+            throw GIFVideoTranscodeError.pixelBufferCreationFailed(status)
+        }
+
+        CVPixelBufferLockBaseAddress(pixelBuffer, [])
+        defer {
+            CVPixelBufferUnlockBaseAddress(pixelBuffer, [])
+        }
+
+        guard let baseAddress = CVPixelBufferGetBaseAddress(pixelBuffer) else {
+            throw GIFVideoTranscodeError.pixelBufferBaseAddressUnavailable
+        }
+
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        let bitmapInfo = CGBitmapInfo.byteOrder32Little.union(CGBitmapInfo(rawValue: CGImageAlphaInfo.premultipliedFirst.rawValue))
+        guard let context = CGContext(data: baseAddress,
+                                      width: videoSize.width,
+                                      height: videoSize.height,
+                                      bitsPerComponent: 8,
+                                      bytesPerRow: CVPixelBufferGetBytesPerRow(pixelBuffer),
+                                      space: colorSpace,
+                                      bitmapInfo: bitmapInfo.rawValue) else {
+            throw GIFVideoTranscodeError.pixelBufferContextUnavailable
+        }
+
+        let rect = CGRect(x: 0, y: 0, width: videoSize.width, height: videoSize.height)
+        context.clear(rect)
+        context.interpolationQuality = .medium
+        // AVAssetWriter displays this pixel buffer upright when the ImageIO frame is drawn directly.
+        context.draw(image, in: rect)
+        return pixelBuffer
+    }
+
+    private static func videoOutputSettings(videoSize: VideoSize) -> [String: Any] {
+        [
+            AVVideoCodecKey: AVVideoCodecType.h264,
+            AVVideoWidthKey: videoSize.width,
+            AVVideoHeightKey: videoSize.height,
+            AVVideoCompressionPropertiesKey: [
+                AVVideoAverageBitRateKey: max(400_000, videoSize.width * videoSize.height * 4),
+                AVVideoProfileLevelKey: AVVideoProfileLevelH264MainAutoLevel
+            ]
+        ]
+    }
+
+    private static func pixelBufferAttributes(videoSize: VideoSize) -> [String: Any] {
+        [
+            kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA,
+            kCVPixelBufferWidthKey as String: videoSize.width,
+            kCVPixelBufferHeightKey as String: videoSize.height,
+            kCVPixelBufferIOSurfacePropertiesKey as String: [:]
+        ]
+    }
+
+    private static func outputVideoSize(sourceWidth: Int, sourceHeight: Int, maxPixelSize: CGSize?) -> VideoSize {
+        var width = max(2, sourceWidth)
+        var height = max(2, sourceHeight)
+
+        if let maxPixelSize,
+           maxPixelSize.width > 1,
+           maxPixelSize.height > 1 {
+            let scale = min(1,
+                            maxPixelSize.width / CGFloat(width),
+                            maxPixelSize.height / CGFloat(height))
+            width = max(2, Int((CGFloat(width) * scale).rounded(.down)))
+            height = max(2, Int((CGFloat(height) * scale).rounded(.down)))
+        }
+
+        width -= width % 2
+        height -= height % 2
+        return VideoSize(width: max(2, width), height: max(2, height))
+    }
+
+    private static func frameDuration(imageSource: CGImageSource, index: Int) -> TimeInterval {
+        guard let properties = CGImageSourceCopyPropertiesAtIndex(imageSource, index, nil) as? [CFString: Any],
+              let gifProperties = properties[kCGImagePropertyGIFDictionary] as? [CFString: Any] else {
+            return 0.1
+        }
+
+        let unclampedDelay = gifProperties[kCGImagePropertyGIFUnclampedDelayTime] as? TimeInterval
+        let clampedDelay = gifProperties[kCGImagePropertyGIFDelayTime] as? TimeInterval
+        return max(unclampedDelay ?? clampedDelay ?? 0.1, 0.02)
+    }
+
+    private static func cacheLocation(for gifURL: URL, maxPixelSize: CGSize?) throws -> CacheLocation {
+        guard let cachesDirectory = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first else {
+            throw GIFVideoTranscodeError.cacheDirectoryUnavailable
+        }
+
+        let attributes = try? FileManager.default.attributesOfItem(atPath: gifURL.path)
+        let modifiedAt = (attributes?[.modificationDate] as? Date)?.timeIntervalSince1970 ?? 0
+        let fileSize = (attributes?[.size] as? NSNumber)?.int64Value ?? 0
+        let pixelKey = pixelCacheKey(maxPixelSize)
+        let rawKey = "\(cacheFormatVersion)|\(gifURL.path)|\(modifiedAt)|\(fileSize)|\(pixelKey)"
+        let digest = SHA256.hash(data: Data(rawKey.utf8))
+            .map { String(format: "%02x", $0) }
+            .joined()
+        let directory = cachesDirectory.appendingPathComponent("URLImageGIFVideoCache", isDirectory: true)
+        let videoURL = directory.appendingPathComponent(digest).appendingPathExtension("mp4")
+        let temporaryURL = directory.appendingPathComponent("\(digest)-\(UUID().uuidString).tmp").appendingPathExtension("mp4")
+
+        return CacheLocation(key: digest, videoURL: videoURL, temporaryURL: temporaryURL)
+    }
+
+    private static func pixelCacheKey(_ maxPixelSize: CGSize?) -> String {
+        guard let maxPixelSize else {
+            return "original"
+        }
+
+        let width = max(0, Int(maxPixelSize.width.rounded(.up)))
+        let height = max(0, Int(maxPixelSize.height.rounded(.up)))
+        return "\(width)x\(height)"
+    }
+}
+
+@available(macOS 11.0, *)
+private actor GIFVideoTranscodeLimiter {
+    private let maxConcurrentJobs: Int
+    private var runningJobs = 0
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    init(maxConcurrentJobs: Int) {
+        self.maxConcurrentJobs = max(1, maxConcurrentJobs)
+    }
+
+    func acquire() async {
+        if runningJobs < maxConcurrentJobs {
+            runningJobs += 1
+            return
+        }
+
+        await withCheckedContinuation { continuation in
+            waiters.append(continuation)
+        }
+    }
+
+    func release() {
+        if waiters.isEmpty {
+            runningJobs = max(0, runningJobs - 1)
+        } else {
+            waiters.removeFirst().resume()
+        }
+    }
+}
+
+private struct CacheLocation: Sendable {
+    let key: String
+    let videoURL: URL
+    let temporaryURL: URL
+}
+
+private struct VideoSize: Sendable {
+    let width: Int
+    let height: Int
+}
+
+private enum GIFVideoTranscodeError: Error, CustomStringConvertible {
+    case cacheDirectoryUnavailable
+    case imageSourceUnavailable
+    case frameUnavailable(index: Int)
+    case assetWriterInputRejected
+    case assetWriterFailed(String)
+    case pixelBufferPoolUnavailable
+    case pixelBufferCreationFailed(CVReturn)
+    case pixelBufferBaseAddressUnavailable
+    case pixelBufferContextUnavailable
+
+    var description: String {
+        switch self {
+        case .cacheDirectoryUnavailable:
+            return "cache directory unavailable"
+        case .imageSourceUnavailable:
+            return "image source unavailable"
+        case .frameUnavailable(let index):
+            return "frame unavailable index=\(index)"
+        case .assetWriterInputRejected:
+            return "asset writer input rejected"
+        case .assetWriterFailed(let message):
+            return "asset writer failed \(message)"
+        case .pixelBufferPoolUnavailable:
+            return "pixel buffer pool unavailable"
+        case .pixelBufferCreationFailed(let status):
+            return "pixel buffer creation failed status=\(status)"
+        case .pixelBufferBaseAddressUnavailable:
+            return "pixel buffer base address unavailable"
+        case .pixelBufferContextUnavailable:
+            return "pixel buffer context unavailable"
+        }
+    }
+}
+#endif

--- a/Sources/URLImage/Views/MacAnimatedGIFView.swift
+++ b/Sources/URLImage/Views/MacAnimatedGIFView.swift
@@ -1,0 +1,391 @@
+#if os(macOS)
+import AppKit
+import AVFoundation
+import os
+
+@available(macOS 11.0, *)
+final class MacAnimatedGIFView: PlatformView {
+    private static let logger = Logger(subsystem: "com.groovy.ca", category: "GIFPlayback")
+
+    private let displayLayer = CALayer()
+    private let playerLayer = AVPlayerLayer()
+    private var currentFileURL: URL?
+    private var currentMaxPixelSize: CGSize?
+    private var playbackMode: GIFPlaybackMode = .animated
+    private var playbackEngine: GIFPlaybackEngine?
+    private var posterTask: Task<Void, Never>?
+    private var videoTask: Task<Void, Never>?
+    private var videoPlayer: AVPlayer?
+    private var currentVideoURL: URL?
+    private var playbackLoopObserver: NSObjectProtocol?
+    private var fallbackImage: NSImage?
+    private var posterFrame: CGImage?
+#if DEBUG
+    private var renderedFrameCount = 0
+    private var lastFrameLogTime: TimeInterval = 0
+#endif
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        wantsLayer = true
+        layer = CALayer()
+        layer?.masksToBounds = true
+        displayLayer.contentsGravity = .resizeAspect
+        playerLayer.videoGravity = .resizeAspect
+        playerLayer.isHidden = true
+        layer?.addSublayer(displayLayer)
+        layer?.addSublayer(playerLayer)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func layout() {
+        super.layout()
+        displayLayer.frame = bounds
+        playerLayer.frame = bounds
+    }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+
+        guard window != nil else {
+            Self.logger.debug("mac gif window detached url=\(self.currentFileURL?.lastPathComponent ?? "-", privacy: .public)")
+            stopVideoPlayback(cancelTranscodeTask: true)
+            playbackEngine?.showPoster()
+            return
+        }
+
+        if let currentFileURL {
+            applyPlaybackMode(fileURL: currentFileURL, maxPixelSize: currentMaxPixelSize)
+        } else {
+            applyPlaybackMode()
+        }
+    }
+
+    func update(source: GIFImageSource, contentMode: GIFContentMode, playbackMode: GIFPlaybackMode, preferredMaxPixelSize: CGSize?) {
+        displayLayer.contentsGravity = contentMode.layerContentsGravity
+        playerLayer.videoGravity = contentMode.playerVideoGravity
+        self.playbackMode = playbackMode
+
+        switch source {
+        case .image(let image):
+            stopVideoPlayback(cancelTranscodeTask: true)
+            currentFileURL = nil
+            currentMaxPixelSize = nil
+            posterTask?.cancel()
+            posterTask = nil
+            playbackEngine?.invalidate()
+            playbackEngine = nil
+            fallbackImage = image
+            posterFrame = nil
+            applyPlaybackMode()
+        case .file(let url):
+            let maxPixelSize = preferredMaxPixelSize ?? bounds.size.maxPixelSize(backingScaleFactor: window?.backingScaleFactor ?? 1)
+            if currentFileURL != url || currentMaxPixelSize != maxPixelSize {
+                currentFileURL = url
+                currentMaxPixelSize = maxPixelSize
+                fallbackImage = nil
+                posterFrame = nil
+#if DEBUG
+                renderedFrameCount = 0
+                lastFrameLogTime = 0
+#endif
+                posterTask?.cancel()
+                posterTask = nil
+                stopVideoPlayback(cancelTranscodeTask: true)
+                playbackEngine?.invalidate()
+                playbackEngine = nil
+                displayLayer.contents = nil
+            }
+
+            applyPlaybackMode(fileURL: url, maxPixelSize: maxPixelSize)
+        }
+    }
+
+    func reset() {
+        Self.logger.debug("mac gif reset url=\(self.currentFileURL?.lastPathComponent ?? "-", privacy: .public)")
+        currentFileURL = nil
+        currentMaxPixelSize = nil
+        fallbackImage = nil
+        posterFrame = nil
+#if DEBUG
+        renderedFrameCount = 0
+        lastFrameLogTime = 0
+#endif
+        stopVideoPlayback(cancelTranscodeTask: true)
+        posterTask?.cancel()
+        posterTask = nil
+        playbackEngine?.invalidate()
+        playbackEngine = nil
+        displayLayer.contents = nil
+    }
+
+    private func applyPlaybackMode() {
+        stopVideoPlayback(cancelTranscodeTask: true)
+        displayLayer.isHidden = false
+        displayLayer.contents = fallbackImage?.cgImage(forProposedRect: nil, context: nil, hints: nil)
+    }
+
+    private func applyPlaybackMode(fileURL: URL, maxPixelSize: CGSize?) {
+        switch playbackMode {
+        case .animated:
+            posterTask?.cancel()
+            posterTask = nil
+
+            guard window != nil else {
+                Self.logger.debug("mac gif animated requested off-window url=\(fileURL.lastPathComponent, privacy: .public)")
+                stopVideoPlayback(cancelTranscodeTask: true)
+                if let posterFrame {
+                    displayLayer.isHidden = false
+                    displayLayer.contents = posterFrame
+                } else {
+                    showPoster(fileURL: fileURL, maxPixelSize: maxPixelSize)
+                }
+                return
+            }
+
+            startVideoPlayback(fileURL: fileURL, maxPixelSize: maxPixelSize)
+        case .poster:
+            Self.logger.debug("mac gif poster url=\(fileURL.lastPathComponent, privacy: .public)")
+            stopVideoPlayback(cancelTranscodeTask: true)
+            if let posterFrame {
+                displayLayer.isHidden = false
+                displayLayer.contents = posterFrame
+                playbackEngine?.invalidate()
+                playbackEngine = nil
+                posterTask?.cancel()
+                posterTask = nil
+                return
+            }
+
+            showPoster(fileURL: fileURL, maxPixelSize: maxPixelSize)
+        }
+    }
+
+    private func showPoster(fileURL: URL, maxPixelSize: CGSize?) {
+        displayLayer.isHidden = false
+        playerLayer.isHidden = true
+
+        guard posterTask == nil else {
+            return
+        }
+
+        guard let playbackEngine = ensurePlaybackEngine(url: fileURL, maxPixelSize: maxPixelSize) else {
+            displayLayer.contents = posterFrame
+            return
+        }
+
+        posterTask = Task { [weak self, weak playbackEngine] in
+            let poster = await playbackEngine?.posterFrame()
+            guard !Task.isCancelled else {
+                return
+            }
+
+            guard let self else {
+                return
+            }
+
+            if let poster {
+                self.posterFrame = poster
+                self.displayLayer.contents = poster
+            }
+
+            if self.playbackMode == .poster {
+                playbackEngine?.invalidate()
+                if self.playbackEngine === playbackEngine {
+                    self.playbackEngine = nil
+                }
+            } else if self.videoTask != nil {
+                playbackEngine?.invalidate()
+                if self.playbackEngine === playbackEngine {
+                    self.playbackEngine = nil
+                }
+            }
+
+            self.posterTask = nil
+        }
+    }
+
+    private func startVideoPlayback(fileURL: URL, maxPixelSize: CGSize?) {
+        if let currentVideoURL,
+           currentVideoURL == GIFVideoTranscodeCache.shared.cachedVideoURL(for: fileURL, maxPixelSize: maxPixelSize),
+           videoPlayer != nil {
+            displayLayer.isHidden = true
+            playerLayer.isHidden = false
+            videoPlayer?.play()
+            return
+        }
+
+        if let cachedVideoURL = GIFVideoTranscodeCache.shared.cachedVideoURL(for: fileURL, maxPixelSize: maxPixelSize) {
+            startVideoPlayer(videoURL: cachedVideoURL, sourceURL: fileURL)
+            return
+        }
+
+        showPoster(fileURL: fileURL, maxPixelSize: maxPixelSize)
+
+        guard videoTask == nil else {
+            return
+        }
+
+        Self.logger.notice("mac gif video requested source=\(fileURL.lastPathComponent, privacy: .public) maxPixel=\(String(describing: maxPixelSize), privacy: .public)")
+        videoTask = Task { @MainActor [weak self] in
+            do {
+                let videoURL = try await GIFVideoTranscodeCache.shared.videoURL(for: fileURL, maxPixelSize: maxPixelSize)
+                guard !Task.isCancelled,
+                      let self,
+                      self.currentFileURL == fileURL,
+                      self.playbackMode == .animated,
+                      self.window != nil else {
+                    return
+                }
+
+                self.videoTask = nil
+                self.startVideoPlayer(videoURL: videoURL, sourceURL: fileURL)
+            } catch is CancellationError {
+                guard let self, self.currentFileURL == fileURL else {
+                    return
+                }
+                self.videoTask = nil
+            } catch {
+                guard let self,
+                      self.currentFileURL == fileURL,
+                      self.playbackMode == .animated,
+                      self.window != nil else {
+                    return
+                }
+
+                self.videoTask = nil
+                self.startFrameEngineFallback(fileURL: fileURL, maxPixelSize: maxPixelSize, error: error)
+            }
+        }
+    }
+
+    private func startVideoPlayer(videoURL: URL, sourceURL: URL) {
+        if currentVideoURL == videoURL, videoPlayer != nil {
+            displayLayer.isHidden = true
+            playerLayer.isHidden = false
+            videoPlayer?.play()
+            return
+        }
+
+        stopVideoPlayback(cancelTranscodeTask: false)
+        playbackEngine?.invalidate()
+        playbackEngine = nil
+
+        let playerItem = AVPlayerItem(url: videoURL)
+        let player = AVPlayer(playerItem: playerItem)
+        player.actionAtItemEnd = .none
+        videoPlayer = player
+        currentVideoURL = videoURL
+        playerLayer.player = player
+        displayLayer.isHidden = true
+        playerLayer.isHidden = false
+        playbackLoopObserver = NotificationCenter.default.addObserver(forName: .AVPlayerItemDidPlayToEndTime,
+                                                                       object: playerItem,
+                                                                       queue: .main) { [weak player] _ in
+            Task { @MainActor [weak player] in
+                player?.seek(to: .zero)
+                player?.play()
+            }
+        }
+
+        Self.logger.notice("mac gif video play source=\(sourceURL.lastPathComponent, privacy: .public) video=\(videoURL.lastPathComponent, privacy: .public)")
+        player.play()
+    }
+
+    private func startFrameEngineFallback(fileURL: URL, maxPixelSize: CGSize?, error: Error) {
+        Self.logger.error("mac gif video fallback source=\(fileURL.lastPathComponent, privacy: .public) error=\(String(describing: error), privacy: .public)")
+        stopVideoPlayback(cancelTranscodeTask: false)
+        displayLayer.isHidden = false
+
+        guard let playbackEngine = ensurePlaybackEngine(url: fileURL, maxPixelSize: maxPixelSize) else {
+            displayLayer.contents = posterFrame
+            return
+        }
+
+        Self.logger.debug("mac gif start url=\(fileURL.lastPathComponent, privacy: .public) maxPixel=\(String(describing: maxPixelSize), privacy: .public)")
+        playbackEngine.start()
+    }
+
+    private func stopVideoPlayback(cancelTranscodeTask: Bool) {
+        if cancelTranscodeTask {
+            videoTask?.cancel()
+            videoTask = nil
+        }
+
+        if let playbackLoopObserver {
+            NotificationCenter.default.removeObserver(playbackLoopObserver)
+            self.playbackLoopObserver = nil
+        }
+
+        videoPlayer?.pause()
+        videoPlayer?.replaceCurrentItem(with: nil)
+        videoPlayer = nil
+        currentVideoURL = nil
+        playerLayer.player = nil
+        playerLayer.isHidden = true
+        displayLayer.isHidden = false
+    }
+
+    private func ensurePlaybackEngine(url: URL, maxPixelSize: CGSize?) -> GIFPlaybackEngine? {
+        if let playbackEngine {
+            return playbackEngine
+        }
+
+        let playbackEngine = GIFPlaybackEngine(url: url, maxPixelSize: maxPixelSize) { [weak self] frame in
+            guard let self else {
+                return
+            }
+
+            if self.posterFrame == nil {
+                self.posterFrame = frame
+            }
+
+            self.displayLayer.isHidden = false
+            self.displayLayer.contents = frame
+#if DEBUG
+            self.renderedFrameCount += 1
+            let now = ProcessInfo.processInfo.systemUptime
+            if self.renderedFrameCount <= 3 || now - self.lastFrameLogTime >= 1 {
+                self.lastFrameLogTime = now
+                Self.logger.debug("mac gif frame url=\(self.currentFileURL?.lastPathComponent ?? "-", privacy: .public) count=\(self.renderedFrameCount, privacy: .public) window=\(self.window != nil, privacy: .public) mode=\(String(describing: self.playbackMode), privacy: .public)")
+            }
+#endif
+        }
+        self.playbackEngine = playbackEngine
+        return playbackEngine
+    }
+}
+
+private extension GIFContentMode {
+    var layerContentsGravity: CALayerContentsGravity {
+        switch self {
+        case .fit:
+            return .resizeAspect
+        case .fill:
+            return .resizeAspectFill
+        }
+    }
+
+    var playerVideoGravity: AVLayerVideoGravity {
+        switch self {
+        case .fit:
+            return .resizeAspect
+        case .fill:
+            return .resizeAspectFill
+        }
+    }
+}
+
+private extension CGSize {
+    func maxPixelSize(backingScaleFactor: CGFloat) -> CGSize? {
+        guard width > 0, height > 0 else {
+            return nil
+        }
+
+        return applying(.init(scaleX: backingScaleFactor, y: backingScaleFactor))
+    }
+}
+#endif

--- a/Sources/URLImage/Views/RemoteGIFImageView.swift
+++ b/Sources/URLImage/Views/RemoteGIFImageView.swift
@@ -7,6 +7,12 @@
 
 import SwiftUI
 import Model
+#if os(macOS)
+import os
+
+@available(macOS 11.0, *)
+private let remoteGIFLogger = Logger(subsystem: "com.groovy.ca", category: "GIFPlayback")
+#endif
 
 @available(macOS 12.0, iOS 15.0, tvOS 14.0, watchOS 7.0, *)
 struct RemoteGIFImageView<Empty, InProgress, Failure, Content> : View where Empty : View,
@@ -18,6 +24,7 @@ struct RemoteGIFImageView<Empty, InProgress, Failure, Content> : View where Empt
     @Environment(\.urlImageOptions) var options
     @State private var source: GIFImageSource?
     @State var animateState: RemoteImageLoadingState = .initial
+    let playbackMode: GIFPlaybackMode
 
     let loadOptions: URLImageOptions.LoadOptions
 
@@ -28,6 +35,7 @@ struct RemoteGIFImageView<Empty, InProgress, Failure, Content> : View where Empt
 
     init(remoteImage: RemoteImage,
          loadOptions: URLImageOptions.LoadOptions,
+         playbackMode: GIFPlaybackMode,
          @ViewBuilder empty: @escaping () -> Empty,
          @ViewBuilder inProgress: @escaping (_ progress: Float?) -> InProgress,
          @ViewBuilder failure: @escaping (_ error: Error, _ retry: @escaping () -> Void) -> Failure,
@@ -35,6 +43,7 @@ struct RemoteGIFImageView<Empty, InProgress, Failure, Content> : View where Empt
 
         self.remoteImage = remoteImage
         self.loadOptions = loadOptions
+        self.playbackMode = playbackMode
 
         self.empty = empty
         self.inProgress = inProgress
@@ -55,16 +64,20 @@ struct RemoteGIFImageView<Empty, InProgress, Failure, Content> : View where Empt
             case .inProgress(let progress):
                 inProgress(progress)
                 
-            case .success(let transientImage):
+            case .success:
                 if let source = source {
                     switch source {
                     case .image(let image):
                         content(
-                            GIFImageView(image: image)
+                            GIFImageView(image: image,
+                                         playbackMode: playbackMode,
+                                         preferredMaxPixelSize: options.maxPixelSize)
                         )
                     case .file(let fileURL):
                         content(
-                            GIFImageView(url: fileURL)
+                            GIFImageView(url: fileURL,
+                                         playbackMode: playbackMode,
+                                         preferredMaxPixelSize: options.maxPixelSize)
                         )
                         .disabled(true)
                     }
@@ -78,18 +91,19 @@ struct RemoteGIFImageView<Empty, InProgress, Failure, Content> : View where Empt
             }
         }
         .onAppear {
-            if loadOptions.contains(.loadOnAppear), !remoteImage.slowLoadingState.value.isSuccess {
+            if (loadOptions.contains(.loadOnAppear) || loadOptions.contains(.loadImmediately)),
+               !remoteImage.slowLoadingState.value.isSuccess {
                 remoteImage.load()
             }
             Task {
-                await prepare(self.animateState)
+                await prepare(remoteImage.slowLoadingState.value)
             }
         }
         .onDisappear {
             if loadOptions.contains(.cancelOnDisappear) {
                 remoteImage.cancel()
             }
-//            image = nil
+            remoteImage.onDissAppear()
         }
         .onReceive(remoteImage.slowLoadingState) { newValue in
             Task {
@@ -100,13 +114,29 @@ struct RemoteGIFImageView<Empty, InProgress, Failure, Content> : View where Empt
     }
     
     private func prepare(_ state: RemoteImage.LoadingState) async {
-        if case .success(_) = state {
-            if let image = await loadMemoryStore(options.maxPixelSize) {
-                self.source = .image(image)
-                return
-            }
-            await load(options.maxPixelSize)
+        guard case .success(_) = state else {
+            return
         }
+
+        if source != nil {
+            return
+        }
+
+#if os(macOS)
+        if urlImageService.fileStore != nil {
+            await load(options.maxPixelSize)
+            return
+        }
+#endif
+
+        if let image = await loadMemoryStore(options.maxPixelSize) {
+            await MainActor.run {
+                source = .image(image)
+            }
+            return
+        }
+
+        await load(options.maxPixelSize)
     }
     
     private func load(_ maxPixelSize: CGSize?) async {
@@ -117,21 +147,27 @@ struct RemoteGIFImageView<Empty, InProgress, Failure, Content> : View where Empt
         
 #if os(macOS)
         do {
-            let value = try await fileStore.getImageLocation(remoteImage.download.url)
-            guard let value, let fileURL = try await fileStore.getImageLocation(remoteImage.download.url) else {
+            guard let fileURL = try await fileStore.getImageLocation(fileKeys) else {
                 return
             }
-            source = .file(fileURL)
+            await MainActor.run {
+#if DEBUG
+                remoteGIFLogger.debug("gif source file remote=\(self.remoteImage.download.url.absoluteString, privacy: .public) local=\(fileURL.lastPathComponent, privacy: .public) mode=\(String(describing: self.playbackMode), privacy: .public) maxPixel=\(String(describing: maxPixelSize), privacy: .public)")
+#endif
+                source = .file(fileURL)
+            }
         } catch {
             print("retrive image with \(remoteImage.download.url) failed. \(error)")
         }
 #else
         do {
             let value = try await fileStore.getImage([.url(remoteImage.download.url)], maxPixelSize: maxPixelSize)
-            guard let value, let data = await gif(value, maxSize: options.maxPixelSize) else {
+            guard let value, let data = await gif(value, maxSize: maxPixelSize) else {
                 return
             }
-            source = .image(data)
+            await MainActor.run {
+                source = .image(data)
+            }
         } catch {
             print("retrive image with \(remoteImage.download.url) failed. \(error)")
         }
@@ -140,16 +176,30 @@ struct RemoteGIFImageView<Empty, InProgress, Failure, Content> : View where Empt
     
     private func loadMemoryStore(_ maxPixelSize: CGSize?) async -> PlatformImage? {
         guard let memoryStore = urlImageService.inMemoryStore else {
-//            print("memory store missing")
             return nil
         }
         
-        guard let value: TransientImage = await memoryStore.getImage([.url(remoteImage.download.url)]) else {
-            print("\(remoteImage.download.url) not cached in memory store")
+        guard let value: TransientImage = await memoryStore.getImage(memoryKeys) else {
             return nil
         }
         
-        return await gif(value, maxSize: options.maxPixelSize)
+        return await gif(value, maxSize: maxPixelSize)
+    }
+
+    private var memoryKeys: [URLImageKey] {
+        if let identifier = remoteImage.identifier {
+            return [.identifier(identifier)]
+        }
+
+        return [.url(remoteImage.download.url)]
+    }
+
+    private var fileKeys: [URLImageKey] {
+        if let identifier = remoteImage.identifier {
+            return [.identifier(identifier), .url(remoteImage.download.url)]
+        }
+
+        return [.url(remoteImage.download.url)]
     }
 }
 

--- a/Sources/URLImage/Views/RemoteGIFImageView.swift
+++ b/Sources/URLImage/Views/RemoteGIFImageView.swift
@@ -140,7 +140,7 @@ struct RemoteGIFImageView<Empty, InProgress, Failure, Content> : View where Empt
     
     private func loadMemoryStore(_ maxPixelSize: CGSize?) async -> PlatformImage? {
         guard let memoryStore = urlImageService.inMemoryStore else {
-            print("memory store missing")
+//            print("memory store missing")
             return nil
         }
         

--- a/Sources/URLImageFFmpeg/EmbeddedFFmpegGIFTranscoder.swift
+++ b/Sources/URLImageFFmpeg/EmbeddedFFmpegGIFTranscoder.swift
@@ -1,0 +1,129 @@
+import CoreGraphics
+import Foundation
+import CURLImageFFmpeg
+
+public struct FFmpegGIFTranscodeRequest: Sendable {
+    public var sourceURL: URL
+    public var outputURL: URL
+    public var maxPixelSize: CGSize?
+
+    public init(sourceURL: URL, outputURL: URL, maxPixelSize: CGSize?) {
+        self.sourceURL = sourceURL
+        self.outputURL = outputURL
+        self.maxPixelSize = maxPixelSize
+    }
+}
+
+public struct FFmpegGIFTranscodePreset: Sendable {
+    public var encoderArguments: [String]
+    public var threadCount: Int
+
+    public init(encoderArguments: [String], threadCount: Int = 2) {
+        self.encoderArguments = encoderArguments
+        self.threadCount = max(1, threadCount)
+    }
+
+    public static let appleH264 = FFmpegGIFTranscodePreset(
+        encoderArguments: [
+            "-c:v", "h264_videotoolbox",
+            "-b:v", "1200k"
+        ]
+    )
+
+    public static let softwareX264 = FFmpegGIFTranscodePreset(
+        encoderArguments: [
+            "-c:v", "libx264",
+            "-preset", "veryfast",
+            "-crf", "24"
+        ]
+    )
+
+    public func processArguments(for request: FFmpegGIFTranscodeRequest) -> [String] {
+        var arguments = [
+            "-y",
+            "-hide_banner",
+            "-loglevel", "error",
+            "-i", request.sourceURL.path,
+            "-an",
+            "-movflags", "+faststart",
+            "-pix_fmt", "yuv420p"
+        ]
+
+        arguments.append(contentsOf: encoderArguments)
+        arguments.append(contentsOf: ["-threads", "\(threadCount)"])
+        arguments.append(contentsOf: ["-vf", Self.videoFilter(maxPixelSize: request.maxPixelSize)])
+        arguments.append(request.outputURL.path)
+        return arguments
+    }
+
+    public static func videoFilter(maxPixelSize: CGSize?) -> String {
+        guard let maxPixelSize,
+              maxPixelSize.width > 1,
+              maxPixelSize.height > 1 else {
+            return "scale=trunc(iw/2)*2:trunc(ih/2)*2"
+        }
+
+        let width = max(2, Int(maxPixelSize.width.rounded(.down)))
+        let height = max(2, Int(maxPixelSize.height.rounded(.down)))
+        return "scale='min(iw,\(width))':'min(ih,\(height))':force_original_aspect_ratio=decrease:force_divisible_by=2"
+    }
+}
+
+public enum EmbeddedFFmpegError: Error, CustomStringConvertible {
+    case binaryNotLinked(configuration: String)
+    case executionFailed(status: Int32)
+
+    public var description: String {
+        switch self {
+        case .binaryNotLinked(let configuration):
+            return "embedded ffmpeg binary is not linked: \(configuration)"
+        case .executionFailed(let status):
+            return "embedded ffmpeg failed status=\(status)"
+        }
+    }
+}
+
+public struct EmbeddedFFmpegGIFTranscoder: Sendable {
+    public var preset: FFmpegGIFTranscodePreset
+
+    public init(preset: FFmpegGIFTranscodePreset = .appleH264) {
+        self.preset = preset
+    }
+
+    public static var isLinked: Bool {
+        urlimage_ffmpeg_is_linked() != 0
+    }
+
+    public static var configuration: String {
+        guard let pointer = urlimage_ffmpeg_configuration() else {
+            return ""
+        }
+
+        return String(cString: pointer)
+    }
+
+    public func transcode(_ request: FFmpegGIFTranscodeRequest) throws {
+        guard Self.isLinked else {
+            throw EmbeddedFFmpegError.binaryNotLinked(configuration: Self.configuration)
+        }
+
+        var arguments = ["ffmpeg"]
+        arguments.append(contentsOf: preset.processArguments(for: request))
+
+        var cArguments = arguments.map { strdup($0) }
+        cArguments.append(nil)
+        defer {
+            for argument in cArguments {
+                free(argument)
+            }
+        }
+
+        let status = cArguments.withUnsafeMutableBufferPointer { buffer in
+            urlimage_ffmpeg_execute(Int32(arguments.count), buffer.baseAddress)
+        }
+
+        guard status == 0 else {
+            throw EmbeddedFFmpegError.executionFailed(status: status)
+        }
+    }
+}

--- a/Sources/URLImageStore/URLImageInMemoryStore.swift
+++ b/Sources/URLImageStore/URLImageInMemoryStore.swift
@@ -50,7 +50,31 @@ public final class URLImageInMemoryStore: Sendable {
     }
 
     @URLImageInMemoryStoreActor
-    private let cache = NSCache<KeyWrapper, ObjectWrapper>()
+    private let cache: NSCache<KeyWrapper, ObjectWrapper> = {
+        let cache = NSCache<KeyWrapper, ObjectWrapper>()
+        cache.countLimit = 160
+#if os(macOS)
+        cache.totalCostLimit = 64 * 1024 * 1024
+#else
+        cache.totalCostLimit = 96 * 1024 * 1024
+#endif
+        return cache
+    }()
+
+    private static func cacheCost(for image: Any) -> Int {
+        guard #available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *) else {
+            return 0
+        }
+
+        guard let transientImage = image as? TransientImage else {
+            return 0
+        }
+
+        let pixelSize = transientImage.proxy.maxPixelSize ?? transientImage.info.size
+        let width = max(Int(pixelSize.width.rounded(.up)), 1)
+        let height = max(Int(pixelSize.height.rounded(.up)), 1)
+        return width * height * 4
+    }
 }
 
 
@@ -94,7 +118,8 @@ extension URLImageInMemoryStore: URLImageInMemoryStoreType {
         let urlKey = URLImageKey.url(info.url)
         let urlKeyWrapper = KeyWrapper(key: urlKey)
         let imageWrapper = ObjectWrapper(image: image, info: info)
-        cache.setObject(imageWrapper, forKey: urlKeyWrapper)
+        let cost = Self.cacheCost(for: image)
+        cache.setObject(imageWrapper, forKey: urlKeyWrapper, cost: cost)
         
         if let identifier = info.identifier {
             let identifierKey = URLImageKey.identifier(identifier)

--- a/Tests/URLImageTests/URLImageTests.swift
+++ b/Tests/URLImageTests/URLImageTests.swift
@@ -1,14 +1,45 @@
 import XCTest
+import SwiftUI
 @testable import URLImage
 
+@available(macOS 11.0, *)
 final class URLImageTests: XCTestCase {
-    func testExample() {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct
-        // results.
+    func testInstalledRemoteViewOnlyStartsImmediateLoadsDuringInstallation() {
+        XCTAssertTrue(
+            InstalledRemoteView<EmptyView>.shouldStartLoadingDuringInstallation(
+                loadOptions: URLImageOptions.LoadOptions.loadImmediately
+            )
+        )
+        XCTAssertFalse(
+            InstalledRemoteView<EmptyView>.shouldStartLoadingDuringInstallation(
+                loadOptions: URLImageOptions.LoadOptions.loadOnAppear
+            )
+        )
+        XCTAssertFalse(
+            InstalledRemoteView<EmptyView>.shouldStartLoadingDuringInstallation(
+                loadOptions: [
+                    URLImageOptions.LoadOptions.loadOnAppear,
+                    URLImageOptions.LoadOptions.cancelOnDisappear
+                ]
+            )
+        )
     }
 
-    static var allTests = [
-        ("testExample", testExample),
+    func testRemoteImageMemoryLookupKeysPreferIdentifierOverURL() {
+        let url = URL(string: "https://example.com/image.gif")!
+
+        XCTAssertEqual(
+            RemoteImage.memoryLookupKeys(identifier: "detail-image", url: url),
+            [.identifier("detail-image")]
+        )
+        XCTAssertEqual(
+            RemoteImage.memoryLookupKeys(identifier: nil, url: url),
+            [.url(url)]
+        )
+    }
+
+    static let allTests = [
+        ("testInstalledRemoteViewOnlyStartsImmediateLoadsDuringInstallation", testInstalledRemoteViewOnlyStartsImmediateLoadsDuringInstallation),
+        ("testRemoteImageMemoryLookupKeysPreferIdentifierOverURL", testRemoteImageMemoryLookupKeysPreferIdentifierOverURL),
     ]
 }

--- a/Vendor/FFmpeg/README.md
+++ b/Vendor/FFmpeg/README.md
@@ -1,0 +1,22 @@
+# URLImage FFmpeg Vendor Drop
+
+This directory is reserved for the vendored FFmpeg binary used by `URLImageFFmpeg`.
+
+Recommended final shape:
+
+1. Build or vendor a signed Apple-platform FFmpeg CLI/library wrapper as an `.xcframework` with slices for `ios-arm64`, `ios-arm64_x86_64-simulator`, `macos-arm64_x86_64`.
+2. Expose a C entry point compatible with `urlimage_ffmpeg_execute(int32_t argc, char * const argv[])`, or replace `Sources/CURLImageFFmpeg/URLImageFFmpegBridge.c` with a bridge that calls the vendor's `ffmpeg_main`.
+3. Add a local SwiftPM binary target in `Package.swift`, for example:
+
+```swift
+.binaryTarget(
+    name: "CFFmpegBinary",
+    path: "Vendor/FFmpeg/CFFmpegBinary.xcframework"
+)
+```
+
+4. Add `"CFFmpegBinary"` as a dependency of the `CURLImageFFmpeg` target after the binary exists locally.
+
+Do not rely on `/opt/homebrew/bin/ffmpeg`, `/usr/local/bin/ffmpeg`, or any other host command-line path. CloudSailor/SnowX macOS builds are sandboxed and hardened, and iOS cannot use an external executable path.
+
+Prefer a VideoToolbox-backed H.264 encoder (`h264_videotoolbox`) for iOS/macOS distribution. Bundling `libx264` normally changes the licensing obligations and should be treated as an explicit product/legal decision.


### PR DESCRIPTION
## Summary
- add macOS GIF playback and video-transcode cache paths
- add URLImageFFmpeg/CURLImageFFmpeg package targets with embedded-transcoder fallback wiring
- improve remote image/cache behavior and cover identifier-preferred memory lookups
- fix FileIndex tests for Swift 6 main-actor wait checks

## Validation
- swift test